### PR TITLE
allow for opening of relative app paths

### DIFF
--- a/lib/open-plus.coffee
+++ b/lib/open-plus.coffee
@@ -66,10 +66,13 @@ module.exports =
     console.log "#{filename} : #{opts}";
 
   fileCheckAndOpen: (file, absolute, editor, opts) ->
+    # have absolute file path able to be used in scope
+    absolutePath = absolute
     # if filename is not absolute, make it absolute relative to current dir
     if path.resolve(file) != file
       filename = path.resolve absolute, file
-
+    else
+      filename = file
     if not fs.existsSync filename
       # if no extension there, attach extension of current file
       if not path.extname filename
@@ -96,14 +99,37 @@ module.exports =
     #if it does not exist
     else
       if absolute == ""
+        atom.confirm
+          message: 'File '+ file + ' does not exist'
+          detailedMessage: 'Create it?'
+          buttons:
+            Ok: ->
+              absolutePath = path.dirname(editor.getPath())
+              absolutePath = absolutePath.split('/').reverse()
+
+              finalPath = path.dirname(editor.getPath())
+              finalPath = finalPath.split('/')
+
+              root = file.split('/').shift()
+
+              for aPath in absolutePath
+                if aPath == root
+                  finalPath.pop()
+                  finalPath = finalPath.join('/')
+                  newFile = path.resolve finalPath, file
+                  atom.workspace.open(newFile, opts)
+                  return
+                else
+                  finalPath.pop()
+                  
+            Cancel: -> return
         return
+
       absolute = absolute.split("/")
       absolute.pop()
       absolute = absolute.join("/")
+      # console.log filename
       @fileCheckAndOpen file, absolute, editor, opts
-
-    # open new file
-    # atom.workspace.open(filename, opts)
 
   openPlus: ->
     editor = atom.workspace.getActiveTextEditor()

--- a/lib/open-plus.coffee
+++ b/lib/open-plus.coffee
@@ -19,7 +19,7 @@ module.exports =
   openPlusView: null
   xikij: null
 
-  filePattern: /[^\s()!$&'"*+,;=]+/g # no spaces or sub-delims from url rfc3986
+  filePattern: /[^\s()!$&'"*+,;={}]+/g # no spaces or sub-delims from url rfc3986
 
   activate: (state) ->
     atom.commands.add "atom-workspace", "open-plus:open", => @openPlus()

--- a/lib/open-plus.coffee
+++ b/lib/open-plus.coffee
@@ -10,9 +10,7 @@ $ npm install isbinaryfile --save
 path         = require 'path'
 fs           = require 'fs'
 isBinaryFile = require 'isbinaryfile'
-# atom         = require 'atom'
-
-{Range} = atom
+{Range}      = require 'atom'
 
 osOpen = require "opener"
 
@@ -60,19 +58,27 @@ module.exports =
         opts.initialColumn = parseInt(m[3])
 
     editor = atom.workspace.getActiveTextEditor()
+    absolute = path.dirname(editor.getPath())
 
+    # check file and open it
+    @fileCheckAndOpen filename, absolute, editor, opts
+
+    console.log "#{filename} : #{opts}";
+
+  fileCheckAndOpen: (file, absolute, editor, opts) ->
     # if filename is not absolute, make it absolute relative to current dir
-    if path.resolve(filename) != filename
-      filename = path.resolve path.dirname(editor.getPath()), filename
+    if path.resolve(file) != file
+      filename = path.resolve absolute, file
 
     if not fs.existsSync filename
       # if no extension there, attach extension of current file
       if not path.extname filename
         filename += path.extname editor.getPath()
 
-    # if file exists, open it
+    #if the file exists
     if fs.existsSync filename
       stat = fs.statSync filename
+
       if stat.isDirectory()
         #console.log "open directory"
         return atom.open pathsToOpen: [filename]
@@ -87,10 +93,17 @@ module.exports =
             column = opts.initialColumn ? 0
             editor.setCursorBufferPosition [opts.initialLine-1, column]
 
-    console.log "#{filename} : #{opts}";
+    #if it does not exist
+    else
+      if absolute == ""
+        return
+      absolute = absolute.split("/")
+      absolute.pop()
+      absolute = absolute.join("/")
+      @fileCheckAndOpen file, absolute, editor, opts
 
     # open new file
-    atom.workspace.open(filename, opts)
+    # atom.workspace.open(filename, opts)
 
   openPlus: ->
     editor = atom.workspace.getActiveTextEditor()


### PR DESCRIPTION
This resolves issue #7 

pulled out some of the existing code and put it in a function that checks if the file exists.  If it doesn't, it pops off the last folder of the base absolute path and then runs the function again until it finds the correct file.

I would argue that this plugin should not open a blank file if the file doesn't exist.  It should really just do nothing. 

I am super open to feedback about my code and would love to optimize it if you think there is a better way to solve absolute app paths
