### PR TITLE
Add support for sass import shorthand

### DIFF
--- a/lib/open-plus.coffee
+++ b/lib/open-plus.coffee
@@ -136,9 +136,21 @@ module.exports =
       filename = path.resolve absolute, file
 
     if not fs.existsSync filename
+      filenameExtension = path.extname filename
+      currentFileExtension = path.extname editor.getPath()
+
       # if no extension there, attach extension of current file
-      if not path.extname filename
-        filename += path.extname editor.getPath()
+      if not filenameExtension
+        # if there is no extension, and it is a sass file
+        if currentFileExtension == '.scss'
+          filenameFile = filename.substring(filename.lastIndexOf('/') + 1, filename.length)
+          # if the filename does not already start with _ ... add the underscore.
+          # Fixes https://github.com/klorenz/atom-open-plus/issues/15
+          if filenameFile.substring(0, 1) != '_'
+            filenamePath = filename.substring(0, filename.lastIndexOf('/') + 1)
+            filename = filenamePath + '_' + filenameFile + currentFileExtension
+        else
+          filename += currentFileExtension
 
     # if the file exists
     if fs.existsSync filename


### PR DESCRIPTION
## Ultimate problem:
#15

For Sass `@import`s, a very popular way to import partials, is to omit the file extension and the underscore prefix. For instance:

Instead of

``` scss
@import 'vendor/_prism.scss';
```

You do this

``` scss
@import 'vendor/prism';
```

However - using your package, an error is thrown when trying to use the latter.

```
Uncaught TypeError: Path must be a string.
```

```
**Atom Version**: 1.2.4
**System**: Mac OS X 10.10.5
**Thrown From**: [open-plus](https://github.com/klorenz/atom-open-plus) package, v0.6.0
```
## How it was fixed:

In the section where you are checking for the lack of a file extension, I added some additional logic to add the `_` prefix to a sass filename.

@klorenz please review
