### PR TITLE
Dirname method

### DIFF
--- a/lib/open-plus.coffee
+++ b/lib/open-plus.coffee
@@ -10,12 +10,19 @@ $ npm install isbinaryfile --save
 path         = require 'path'
 fs           = require 'fs'
 isBinaryFile = require 'isbinaryfile'
-{Range}      = require 'atom'
+{Range} = require 'atom'
 
 osOpen = require "opener"
 
-
 module.exports =
+  config:
+    confirmOpenNewFile:
+      type: "boolean"
+      default: false
+
+    #searchBackFor
+
+
   openPlusView: null
   xikij: null
 
@@ -55,7 +62,7 @@ module.exports =
       filename = m[1]
       opts.initialLine = parseInt(m[2])
       if m[3]
-        opts.initialColumn = parseInt(m[3])
+        opts.initialColumn = parseInt(m[3])-1
 
     editor = atom.workspace.getActiveTextEditor()
     absolute = path.dirname(editor.getPath())
@@ -65,16 +72,79 @@ module.exports =
 
     console.log "#{filename} : #{opts}";
 
+  createFile: (filename, opts) ->
+    {findMatchingPath, editor} = opts
+
+    if not path.extname filename
+      filename += path.extname editor.getPath()
+
+    currentFileDir = path.dirname(editor.getPath())
+
+    newFile = null
+    if not findMatchingPath
+      newFile = path.resolve currentFileDir, filename
+
+    else
+      newFile = path.resolve currentFileDir, filename
+
+      # if there is no relative path in filename
+      if path.sep in filename
+        pathElements = currentFileDir.split(path.sep).reverse()
+
+        # find relative path of current file to project root
+        for prjdir in atom.project.rootDirectories
+          if currentFileDir.startsWith prjdir.path
+            relpath = path.relative(currentFileDir, prjdir)
+            pathElements = relpath.split(path.sep).reverse()
+            break
+
+        finalPath    = currentFileDir
+
+        anchor = filename.split(path.sep).shift()
+
+        # loops through the new path backwards until it finds the app root
+        # TODO: stop on project root ?
+        for aPath in pathElements
+          if aPath != anchor
+            # move up one in the file structure
+            finalPath = path.resolve finalPath, '..'
+          else
+            # move up one in the file structure one more time
+            finalPath = path.resolve finalPath, '..'
+            # resolve the finalPath with the path of the new file and open
+            newFile = path.resolve finalPath, filename
+            break
+
+    return unless newFile
+
+    if not atom.config.get('open-plus.confirmOpenNewFile')
+      atom.workspace.open(newFile, opts)
+
+    else
+      atom.confirm
+        message: 'File '+ newFile + ' does not exist'
+        detailedMessage: 'Create it?'
+        buttons:
+          Ok: -> atom.workspace.open(newFile, opts)
+          Cancel: -> return
+
   fileCheckAndOpen: (file, absolute, editor, opts) ->
     # if filename is not absolute, make it absolute relative to current dir
     if path.isAbsolute(file)
       filename = file
     else
       filename = path.resolve absolute, file
+
     if not fs.existsSync filename
-      # if no extension there, attach extension of current file
-      if not path.extname filename
-        filename += path.extname editor.getPath()
+      dirname = path.dirname filename
+      # find the exists directory while walking the tree
+      if fs.existsSync dirname
+          files = fs.readdirSync dirname
+          for file in files
+              # find the file that matches the one you are selecting
+              if file.indexOf(path.basename filename) > -1
+                  sep = path.sep
+                  filename = dirname + sep + file
 
     # if the file exists
     if fs.existsSync filename
@@ -98,41 +168,16 @@ module.exports =
     else
       # do not create anything for absolute paths
       if path.isAbsolute(file)
-        return
-      # if path reaches root folder
-      if absolute == path.resolve absolute, '..'
-        # show dialog to create a new file
-        atom.confirm
-          message: 'File '+ file + ' does not exist'
-          detailedMessage: 'Create it?'
-          buttons:
-            Ok: ->
-              # creates a new path from the file you are currently on
-              absolutePath = path.dirname(editor.getPath())
-              absolutePath = absolutePath.split(path.sep).reverse()
+        @createFile file, findMatchingPath: false, editor: editor
 
-              # assigns the name of the app root folder and the finalPath
-              root = file.split(path.sep).shift()
-              finalPath = path.dirname(editor.getPath())
+      # reached the project root path
+      else if absolute in (r.path for r in atom.project.rootDirectories)
+        @createFile file, findMatchingPath: true, editor: editor
 
-              # loops through the new path backwards until it finds the app root
-              for aPath in absolutePath
-                if aPath == root
-                  # move up one in the file structure one more time
-                  finalPath = path.resolve finalPath, '..'
-                  # resolve the finalPath with the path of the new file and open
-                  newFile = path.resolve finalPath, file
-                  atom.workspace.open(newFile, opts)
-                  return
-                else
-                  # move up one in the file structure
-                  finalPath = path.resolve finalPath, '..'
-            Cancel: -> return
-        return
+      else
+        absolute = path.resolve absolute, '..'
 
-      absolute = path.resolve absolute, '..'
-
-      @fileCheckAndOpen file, absolute, editor, opts
+        @fileCheckAndOpen file, absolute, editor, opts
 
   openPlus: ->
     editor = atom.workspace.getActiveTextEditor()
@@ -174,14 +219,18 @@ module.exports =
 
       text = editor.getTextInBufferRange range
 
-      marker = editor.markBufferRange range
-      editor.decorateMarker marker, type: "highlight", class: "open-plus"
+      # create marker
+      (->
+        marker = editor.markBufferRange range
+        editor.decorateMarker marker, type: "highlight", class: "open-plus"
 
-      setTimeout (-> marker.destroy()), 2000
+        setTimeout (-> marker.destroy()), 2000
+      )()
 
       # cursor was at some whitespace
       text = "" if text.match /\s/
 
-      @openFile text
+      # do this as timeout to have visual feedback of markers
+      setTimeout (=> @openFile text), 500
 
 # ../../atom-xikij/

--- a/lib/open-plus.coffee
+++ b/lib/open-plus.coffee
@@ -100,7 +100,7 @@ module.exports =
       if path.isAbsolute(file)
         return
       # if path reaches root folder
-      if absolute == path.sep
+      if absolute == path.resolve absolute, '..'
         # show dialog to create a new file
         atom.confirm
           message: 'File '+ file + ' does not exist'


### PR DESCRIPTION
This fixes the errors of selecting something like a .babel and it not having the same extension as the file you are currently in.

The method I used was to check to see if the directory you are currently looking for exists.  If it does, then you look through every file in that directory and find the file that matches the name of the file you are selecting.  From there it updates the file name with the correct extension.

This also solves for the sass _ problem as well.
