### PR TITLE
Change from filename extension method to directory method

### DIFF
--- a/lib/open-plus.coffee
+++ b/lib/open-plus.coffee
@@ -136,21 +136,15 @@ module.exports =
       filename = path.resolve absolute, file
 
     if not fs.existsSync filename
-      filenameExtension = path.extname filename
-      currentFileExtension = path.extname editor.getPath()
-
-      # if no extension there, attach extension of current file
-      if not filenameExtension
-        # if there is no extension, and it is a sass file
-        if currentFileExtension == '.scss'
-          filenameFile = filename.substring(filename.lastIndexOf('/') + 1, filename.length)
-          # if the filename does not already start with _ ... add the underscore.
-          # Fixes https://github.com/klorenz/atom-open-plus/issues/15
-          if filenameFile.substring(0, 1) != '_'
-            filenamePath = filename.substring(0, filename.lastIndexOf('/') + 1)
-            filename = filenamePath + '_' + filenameFile + currentFileExtension
-        else
-          filename += currentFileExtension
+      dirname = path.dirname filename
+      # find the exists directory while walking the tree
+      if fs.existsSync dirname
+          files = fs.readdirSync dirname
+          for file in files
+              # find the file that matches the one you are selecting
+              if file.indexOf(path.basename filename) > -1
+                  sep = path.sep
+                  filename = dirname + sep + file
 
     # if the file exists
     if fs.existsSync filename

--- a/lib/open-plus.coffee
+++ b/lib/open-plus.coffee
@@ -135,17 +135,6 @@ module.exports =
     else
       filename = path.resolve absolute, file
 
-    if not fs.existsSync filename
-      dirname = path.dirname filename
-      # find the exists directory while walking the tree
-      if fs.existsSync dirname
-          files = fs.readdirSync dirname
-          for file in files
-              # find the file that matches the one you are selecting
-              if file.indexOf(path.basename filename) > -1
-                  sep = path.sep
-                  filename = dirname + sep + file
-
     # if the file exists
     if fs.existsSync filename
       stat = fs.statSync filename
@@ -166,6 +155,7 @@ module.exports =
 
     # if file path does not exist
     else
+      dirname = path.dirname filename
       # do not create anything for absolute paths
       if path.isAbsolute(file)
         @createFile file, findMatchingPath: false, editor: editor
@@ -173,6 +163,17 @@ module.exports =
       # reached the project root path
       else if absolute in (r.path for r in atom.project.rootDirectories)
         @createFile file, findMatchingPath: true, editor: editor
+
+      # find if directory exists while walking the tree
+      else if fs.existsSync dirname
+          # read the directory and find if there is a file that matches the selected file
+          files = fs.readdirSync dirname
+          for file in files
+              if file.indexOf(path.basename filename) > -1
+                  sep = path.sep
+                  filename = dirname + sep + file
+          # restart the file checking process with either new extension or same filename
+          @fileCheckAndOpen(filename, absolute, editor, opts)
 
       else
         absolute = path.resolve absolute, '..'

--- a/lib/open-plus.coffee
+++ b/lib/open-plus.coffee
@@ -100,7 +100,7 @@ module.exports =
       if path.isAbsolute(file)
         return
       # if path reaches root folder
-      if absolute == path.sep
+      if absolute == path.resolve absolute, '..'
         # show dialog to create a new file
         atom.confirm
           message: 'File '+ file + ' does not exist'


### PR DESCRIPTION
Before this PR, the code found the filename extension of both the current file and the file being selected.  If the script couldn't find the file during the walk of the directory tree, it would add the extension of the current file onto to the selected file name.

This would be a problem if the selected file had a different file extension than the current file.

To solve this my proposed changes do the following:
1. Get the directory name of the current step in the walking of the directory tree
2. If that directory exists in the project, read it and store the files.
3. Loop through those files and find the one that matches the selected file.
4. Replace the selected filename with the actual filename in the directory.
5. Continue with the file checking with either the new filename or the old one if no file was found.

Example: 

I have a file that has the extension `.jsx` with this import statement:

``` javascript
import Store from 'app/stores/cool_store.babel'
```

When I would use open-plus before it would move to the correct directory in the tree during the walk (`app/stores`) but it would try to find `cool_store.babel` (for this example the program thinks `.babel` is the extension that exists).  This would give me an error.

The proposed changes now looks into the `app/stores` and reads all the files that exist.  It finds one called `cool_store.babel.js` and then replaces `cool_store.babel` so it has the `.js` extension.

This method should also work for the changes recently made for `.scss` files since it does a simple `indexOf()` lookup.
